### PR TITLE
Add support for new version of dry-initializer

### DIFF
--- a/artisanal-model.gemspec
+++ b/artisanal-model.gemspec
@@ -28,6 +28,7 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency "dry-types", ">= 0.13.3"
   spec.add_development_dependency "pry", "~> 0.10"
+  spec.add_development_dependency "rb-readline"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.0"
   spec.add_development_dependency "rspec-its", "~> 1.2"

--- a/lib/artisanal/model/attribute.rb
+++ b/lib/artisanal/model/attribute.rb
@@ -3,9 +3,8 @@ module Artisanal::Model
     attr_reader :name, :type, :options
 
     def initialize(name, coercer=nil, **options)
-      @name = name
+      @name, @options = name, options
       @type = coercer || options[:type]
-      @options = options
 
       # Convert :from option to :as
       if options.has_key? :from
@@ -22,7 +21,7 @@ module Artisanal::Model
 
     def included(base)
       # Create dry-initializer option
-      base.option(name, type_builder, **options)
+      base.option(name, **options.merge(type: type_builder))
 
       # Create writer method
       define_writer(base, name) if options[:writer]


### PR DESCRIPTION
The newest version of dry-initializer doesn't play as nicely with
passing in the type as the second argument to `option`.

Now we always pass it in with the other named arguments.